### PR TITLE
Update morgan and on-headers dependencies to new versions to address Dependabot alert 118

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -21,7 +21,7 @@
         "jwk-to-pem": "^2.0.6",
         "jws": "^4.0.0",
         "mongoose": "^8.9.5",
-        "morgan": "^1.10.0"
+        "morgan": "^1.10.1"
       },
       "devDependencies": {
         "dotenv": "^16.4.5",
@@ -1389,16 +1389,16 @@
       "license": "MIT"
     },
     "node_modules/morgan": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
-      "integrity": "sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.1.tgz",
+      "integrity": "sha512-223dMRJtI/l25dJKWpgij2cMtywuG/WiUKXdvwfbhGKBhy1puASqXwFzmWZ7+K73vUPoR7SS2Qz2cI/g9MKw0A==",
       "license": "MIT",
       "dependencies": {
         "basic-auth": "~2.0.1",
         "debug": "2.6.9",
         "depd": "~2.0.0",
         "on-finished": "~2.3.0",
-        "on-headers": "~1.0.2"
+        "on-headers": "~1.1.0"
       },
       "engines": {
         "node": ">= 0.8.0"
@@ -1596,9 +1596,9 @@
       }
     },
     "node_modules/on-headers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
-      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"

--- a/backend/package.json
+++ b/backend/package.json
@@ -20,7 +20,7 @@
     "jwk-to-pem": "^2.0.6",
     "jws": "^4.0.0",
     "mongoose": "^8.9.5",
-    "morgan": "^1.10.0"
+    "morgan": "^1.10.1"
   },
   "devDependencies": {
     "dotenv": "^16.4.5",


### PR DESCRIPTION
**Purpose:** This PR tests whether changes to the versions of morgan and on-headers 

**What is changed:** changed 2 packages (morgan 1.10.0 to 1.10.1; on-headers 1.0.2 to 1.1.0), and audited 178 packages in 4s

**What to do:**
1. Pull code into your local machine
2. Follow instructions to set local .env variables and then start backend and then frontend
3. Test that the app (locally) correctly creates new short URL entries, and that the Existing URLs table functions correctly