### PR TITLE
Updated Readme files regarding app discontinuation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
-# GDX-Analytics-URL-Shortener
-[![img](https://img.shields.io/badge/Lifecycle-Maturing-007EC6)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md)
+> [!IMPORTANT]
+> GDX-Analytics-URL-Shortener application has been discontinued and is no longer maintained.
+
+# GDX-Analytics-URL-Shortener (Discontinued)
+
+[![Lifecycle:Retired](https://img.shields.io/badge/Lifecycle-Retired-d45500)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md)
+
 ---
 A URL shortener service that generates shorter URLs and redirects short URLs to full URLs.
  
@@ -9,9 +14,7 @@ The GDX URL Shortener Project is a GDX Analytics project supported by GCPE that 
  
 ## Project Status
 
-This project is currently under development and actively supported by the GDX Analytics Team.
-
-Check the backend/ and frontend/ folders for their respective Readme and installation steps.
+This repository is no longer maintained.
  
 ## Contents by Directory:
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The GDX URL Shortener Project is a GDX Analytics project supported by GCPE that 
  
 ## Project Status
 
-This repository is no longer maintained.
+GDX-Analytics-URL-Shortener application development has been paused.
  
 ## Contents by Directory:
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # GDX-Analytics-URL-Shortener (Discontinued)
 
-[![Lifecycle:Retired](https://img.shields.io/badge/Lifecycle-Retired-d45500)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md)
+[![Lifecycle:Dormant](https://img.shields.io/badge/Lifecycle-Dormant-ff7f2a)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md)
 
 ---
 A URL shortener service that generates shorter URLs and redirects short URLs to full URLs.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 > [!IMPORTANT]
-> GDX-Analytics-URL-Shortener application has been discontinued and is no longer maintained.
+> GDX-Analytics-URL-Shortener application development has been paused.
 
 # GDX-Analytics-URL-Shortener (Discontinued)
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -3,7 +3,7 @@
 
 # URL-S Backend (Discontinued)
 
-[![Lifecycle:Retired](https://img.shields.io/badge/Lifecycle-Retired-d45500)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md)
+[![Lifecycle:Dormant](https://img.shields.io/badge/Lifecycle-Dormant-ff7f2a)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md)
 
 Instructions for configuring and starting the URL-S backend apps: Node.js Express and MongoDB.
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,5 +1,5 @@
 > [!IMPORTANT]
-> GDX-Analytics-URL-Shortener application has been discontinued and is no longer maintained.
+> GDX-Analytics-URL-Shortener application development has been paused.
 
 # URL-S Backend (Discontinued)
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,4 +1,9 @@
-# URL-S Backend
+> [!IMPORTANT]
+> GDX-Analytics-URL-Shortener application has been discontinued and is no longer maintained.
+
+# URL-S Backend (Discontinued)
+
+[![Lifecycle:Retired](https://img.shields.io/badge/Lifecycle-Retired-d45500)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md)
 
 Instructions for configuring and starting the URL-S backend apps: Node.js Express and MongoDB.
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,4 +1,9 @@
-# URL-S Frontend
+> [!IMPORTANT]
+> GDX-Analytics-URL-Shortener application has been discontinued and is no longer maintained.
+
+# URL-S Frontend (Discontinued)
+
+[![Lifecycle:Retired](https://img.shields.io/badge/Lifecycle-Retired-d45500)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md)
 
 Instructions for configuring and starting the URL-S frontend app, Vue.js, and its dependencies.
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -3,7 +3,7 @@
 
 # URL-S Frontend (Discontinued)
 
-[![Lifecycle:Retired](https://img.shields.io/badge/Lifecycle-Retired-d45500)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md)
+[![Lifecycle:Dormant](https://img.shields.io/badge/Lifecycle-Dormant-ff7f2a)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md)
 
 Instructions for configuring and starting the URL-S frontend app, Vue.js, and its dependencies.
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,5 +1,5 @@
 > [!IMPORTANT]
-> GDX-Analytics-URL-Shortener application has been discontinued and is no longer maintained.
+> GDX-Analytics-URL-Shortener application development has been paused.
 
 # URL-S Frontend (Discontinued)
 


### PR DESCRIPTION
GDX-Analytics-URL-Shortener application has been discontinued and is no longer maintained.
We have updated Readme files accordingly.